### PR TITLE
Add coreutils into OSX/Homebrew installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pip install lit
 
 ```
 xcode-select --install
-brew install git autoconf automake libtool pkg-config protobuf
+brew install git autoconf automake libtool pkg-config protobuf coreutils
 ```
 
 ## Compilation Instructions


### PR DESCRIPTION
[Why] Installation on OSX (10.13.6) encounters (build.sh normal), which suggests missing `realpath` executable
```
/Users/tingfan/umbo/onnc-umbrella/src/configure: line 18770: realpath: command not found
checking SkyPat... configure: error: in `/Users/tingfan/umbo/onnc-umbrella/build-normal':
configure: error: failed to find SkyPat headers
See `config.log' for more details
```
[How] Install coreutils  which contains `realpath`
[What] `brew install coreutils`