### PR TITLE
Move onnx-as & onnx-dis from onnc source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 build
 build-*
 install-*
-docker/*.log
 onncroot
 GPATH
 GRTAGS
 GTAGS
 __pycache__
+external/llvm

--- a/build.cmake.sh
+++ b/build.cmake.sh
@@ -192,6 +192,32 @@ function build_onnc
   popd > /dev/null
 }
 
+function build_tools
+{
+  show "building onnc-umbrella tools..."
+
+  local ONNC_UMBRELLA_BUILDDIR=${ONNC_BUILDDIR}/umbrella
+  local ONNC_UMBRELLA_SOURCEDIR=${PWD}
+
+  show "create build directory at '${ONNC_UMBRELLA_BUILDDIR}/tools'"
+  mkdir -p ${ONNC_UMBRELLA_BUILDDIR}/tools
+
+  pushd "${ONNC_UMBRELLA_BUILDDIR}/tools" > /dev/null
+    local TOOLS_SRC_DIR=${ONNC_UMBRELLA_SOURCEDIR}/tools
+    for TOOL in `ls ${TOOLS_SRC_DIR}`; do
+      if [ -f ${TOOLS_SRC_DIR}/$TOOL/Makefile ] || [ -f ${TOOLS_SRC_DIR}/$TOOL/makefile ] ; then
+        show "building tools: '$TOOL'"
+        mkdir -p $TOOL
+        make -C ${TOOLS_SRC_DIR}/$TOOL \
+          BUILD_DIR=${PWD}/$TOOL \
+          INSTALL_DIR=${ONNC_DESTDIR}${ONNC_PREFIX} \
+          EXTERNAL_DIR=${ONNC_EXTDIR} \
+          install
+      fi
+    done
+  popd > /dev/null
+}
+
 ##===----------------------------------------------------------------------===##
 # Packaging functions
 ##===----------------------------------------------------------------------===##
@@ -240,7 +266,7 @@ fi
 # Parse arguments and setup environment
 setup_environment "$@"
 
-# Build external libraries and libonnc
+# Build external libraries, libonnc and tools
 if [ "${BUILD_EXTERNAL}" != "false" ]; then
   build_external
   if [ "${EXTERNAL_ONLY}" = "true" ]; then
@@ -248,6 +274,7 @@ if [ "${BUILD_EXTERNAL}" != "false" ]; then
   fi
 fi
 build_onnc
+build_tools
 
 # Package the installer
 package_tarball

--- a/build.sh
+++ b/build.sh
@@ -187,6 +187,32 @@ function build_onnc
   popd > /dev/null
 }
 
+function build_tools
+{
+  show "building onnc-umbrella tools..."
+
+  local ONNC_UMBRELLA_BUILDDIR=${ONNC_BUILDDIR}/umbrella
+  local ONNC_UMBRELLA_SOURCEDIR=${PWD}
+
+  show "create build directory at '${ONNC_UMBRELLA_BUILDDIR}/tools'"
+  mkdir -p ${ONNC_UMBRELLA_BUILDDIR}/tools
+
+  pushd "${ONNC_UMBRELLA_BUILDDIR}/tools" > /dev/null
+    local TOOLS_SRC_DIR=${ONNC_UMBRELLA_SOURCEDIR}/tools
+    for TOOL in `ls ${TOOLS_SRC_DIR}`; do
+      if [ -f ${TOOLS_SRC_DIR}/$TOOL/Makefile ] || [ -f ${TOOLS_SRC_DIR}/$TOOL/makefile ] ; then
+        show "building tools: '$TOOL'"
+        mkdir -p $TOOL
+        make -C ${TOOLS_SRC_DIR}/$TOOL \
+          BUILD_DIR=${PWD}/$TOOL \
+          INSTALL_DIR=${ONNC_DESTDIR}${ONNC_PREFIX} \
+          EXTERNAL_DIR=${ONNC_EXTDIR} \
+          install
+      fi
+    done
+  popd > /dev/null
+}
+
 ##===----------------------------------------------------------------------===##
 # Packaging functions
 ##===----------------------------------------------------------------------===##
@@ -243,6 +269,7 @@ if [ "${BUILD_EXTERNAL}" != "false" ]; then
   fi
 fi
 build_onnc
+build_tools
 
 # Package the installer
 package_tarball

--- a/tools/onnx-as/Makefile
+++ b/tools/onnx-as/Makefile
@@ -1,0 +1,19 @@
+CXXFLAGS = -std=c++14 -DONNX_NAMESPACE=onnx
+INCLUDE_DIRS = $(INSTALL_DIR)/include $(EXTERNAL_DIR)/include
+LIBRARY_DIRS = $(INSTALL_DIR)/lib $(EXTERNAL_DIR)/lib
+LFLAGS = -lonnc -lonnx -lonnx_proto -lprotobuf
+
+EXEC = onnx-as
+
+.PHONY: all clean install
+
+all: $(BUILD_DIR)/$(EXEC)
+
+$(BUILD_DIR)/$(EXEC) : main.cpp
+	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$(EXEC) $(addprefix -I, $(INCLUDE_DIRS)) $(addprefix -L, $(LIBRARY_DIRS)) $(LFLAGS) $<
+
+install: $(BUILD_DIR)/$(EXEC)
+	cp $(BUILD_DIR)/$(EXEC) $(INSTALL_DIR)/bin/$(EXEC)
+
+clean:
+	rm -f $(BUILD_DIR)/$(EXEC)

--- a/tools/onnx-as/main.cpp
+++ b/tools/onnx-as/main.cpp
@@ -1,0 +1,98 @@
+//===- main.cpp -----------------------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+#include <onnc/Option/CommandLine.h>
+#include <onnc/Config/AboutData.h>
+#include <onnc/Config/ONNX.h>
+#include <onnc/Support/IOStream.h>
+#include <onnc/Support/OFStream.h>
+#include <onnc/Support/FileHandle.h>
+#include <onnc/Support/FileDescriptor.h>
+#include <google/protobuf/io/zero_copy_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <google/protobuf/text_format.h>
+#include <onnx/common/ir_pb_converter.h>
+#include <string>
+
+using namespace onnc;
+
+//===----------------------------------------------------------------------===//
+// Command Line Option
+//===----------------------------------------------------------------------===//
+static AboutData g_About("onnx-as",
+                         "onnx-as",
+                         "0.9",
+                         AboutLicense::kPrivate,
+                         "onnx.s -> .onnx assembler");
+
+static cl::opt<std::string> InputFilename(cl::kPositional,
+                                          cl::kOptional,
+                                          cl::desc("<input .onnx.s file>"),
+                                          cl::init("-"),
+                                          cl::about(g_About));
+
+static cl::opt<std::string> OutputFilename("o",
+                                           cl::kOptional,
+                                           cl::kValueRequired,
+                                           cl::desc("Override output filename"),
+                                           cl::value_desc("filename"),
+                                           cl::about(g_About));
+
+static cl::opt<bool> OptHelp("help", cl::kLong,
+                             cl::desc("help"), cl::about(g_About));
+
+static cl::alias HelpAliasH("h", cl::kShort, cl::trueopt(OptHelp));
+static cl::alias HelpAliasQ("?", cl::kShort, cl::trueopt(OptHelp));
+
+//===----------------------------------------------------------------------===//
+// Main procedure
+//===----------------------------------------------------------------------===//
+int main(int pArgc, char *pArgv[])
+{
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  cl::ParseCommandLine(pArgc, pArgv);
+  if (OptHelp) {
+    g_About.print(outs());
+    return EXIT_SUCCESS;
+  }
+
+  xProto model;
+  if (InputFilename.hasOccurrence() && InputFilename != "-") {
+    // use file name
+    FileHandle file;
+    file.open(InputFilename, FileHandle::kReadOnly);
+    ::google::protobuf::io::FileInputStream input(file.handler());
+    if (!::google::protobuf::TextFormat::Parse(&input, &model)) {
+      file.close();
+      google::protobuf::ShutdownProtobufLibrary();
+      return EXIT_FAILURE;
+    }
+  }
+  else {
+    // use stdin
+    ::google::protobuf::io::FileInputStream input(STDIN_FILENO);
+    if (!::google::protobuf::TextFormat::Parse(&input, &model)) {
+      google::protobuf::ShutdownProtobufLibrary();
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (OutputFilename.empty()) {
+    std::string output;
+    model.SerializeToString(&output);
+    outs() << output;
+  }
+  else {
+    OFStream output(OutputFilename,
+                        std::ios::out | std::ios::trunc | std::ios::binary);
+    model.SerializeToOstream(&output);
+  }
+
+  google::protobuf::ShutdownProtobufLibrary();
+  return EXIT_SUCCESS;
+}

--- a/tools/onnx-dis/Makefile
+++ b/tools/onnx-dis/Makefile
@@ -1,0 +1,19 @@
+CXXFLAGS = -std=c++14 -DONNX_NAMESPACE=onnx
+INCLUDE_DIRS = $(INSTALL_DIR)/include $(EXTERNAL_DIR)/include
+LIBRARY_DIRS = $(INSTALL_DIR)/lib $(EXTERNAL_DIR)/lib
+LFLAGS = -lonnc -lonnx -lonnx_proto -lprotobuf
+
+EXEC = onnx-dis
+
+.PHONY: all clean install
+
+all: $(BUILD_DIR)/$(EXEC)
+
+$(BUILD_DIR)/$(EXEC) : main.cpp
+	$(CXX) $(CXXFLAGS) -o $(BUILD_DIR)/$(EXEC) $(addprefix -I, $(INCLUDE_DIRS)) $(addprefix -L, $(LIBRARY_DIRS)) $(LFLAGS) $<
+
+install: $(BUILD_DIR)/$(EXEC)
+	cp $(BUILD_DIR)/$(EXEC) $(INSTALL_DIR)/bin/$(EXEC)
+
+clean:
+	rm -f $(BUILD_DIR)/$(EXEC)

--- a/tools/onnx-dis/main.cpp
+++ b/tools/onnx-dis/main.cpp
@@ -1,0 +1,185 @@
+//===- main.cpp -----------------------------------------------------------===//
+//
+//                             The ONNC Project
+//
+// See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+// onnx-dis IGNORES init data in model for readability
+// output can be pass to onnx-as as a new  onnx.model binary without init data
+#include <onnc/Option/CommandLine.h>
+#include <onnc/Config/AboutData.h>
+#include <onnc/Config/ONNX.h>
+#include <onnc/Support/IOStream.h>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/zero_copy_stream_impl.h>
+#include <onnx/common/ir_pb_converter.h>
+#include <fstream>
+#include <string>
+
+using namespace onnc;
+using namespace std;
+
+//===----------------------------------------------------------------------===//
+// Command Line Options
+//===----------------------------------------------------------------------===//
+static AboutData g_About("onnx-dis",
+                         "onnx-dis",
+                         "0.9",
+                         AboutLicense::kUnknown,
+                         ".onnx -> .onnx.s disassembler");
+
+static cl::opt<std::string> InputFilename(cl::kPositional,
+                                          cl::desc("<input .onnx.s file>"),
+                                          cl::init("-"),
+                                          cl::about(g_About));
+
+static cl::opt<bool> DumpWeight("dump-weight",
+                                cl::desc("Dump wegiht"),
+                                cl::about(g_About));
+
+static cl::opt<bool> OptHelp("help", cl::kLong, cl::desc("help"),
+                             cl::about(g_About));
+
+static cl::alias HelpAliasH("h", cl::kShort, cl::trueopt(OptHelp));
+static cl::alias HelpAliasQ("?", cl::kShort, cl::trueopt(OptHelp));
+
+//===----------------------------------------------------------------------===//
+// Procedures
+//===----------------------------------------------------------------------===//
+template <class T> static void dumpRawTensor(const std::string &pRaw)
+{
+  vector<T> data(pRaw.size() / (sizeof(T) / sizeof(char)));
+  memcpy(data.data(), pRaw.data(), pRaw.size());
+  for (auto &i : data) {
+    if (!std::is_same<T, float>::value)
+      cout << (int)i << ", ";
+    else
+      cout << i << ", ";
+  }
+}
+
+static void dumpNodeProto(
+    const ::google::protobuf::RepeatedPtrField< xNodeProto> &pNodes,
+    set<string> &pReshapeInputs)
+{
+  int i;
+  ::google::protobuf::RepeatedPtrField<const xNodeProto>::iterator it;
+
+  for (it = pNodes.begin(); it != pNodes.end(); it++) {
+    cout << "  node { ";
+
+    if (it->op_type() == "Reshape") {
+      for (i = 0; i < it->input_size(); i++)
+        pReshapeInputs.insert(it->input(i));
+    }
+
+    cout << it->ShortDebugString();
+    cout << " }\n";
+  }
+}
+
+static void dumpTensorProto(
+    const ::google::protobuf::RepeatedPtrField< xTensorProto> &pTensors,
+    set<string> &pReshapeInputs)
+
+{
+  ::google::protobuf::RepeatedPtrField<const xTensorProto>::iterator it;
+  set<string>::iterator itReshape;
+
+  for (it = pTensors.begin(); it != pTensors.end(); it++) {
+    if (!DumpWeight) {
+      itReshape = pReshapeInputs.find(it->name());
+      if (itReshape == pReshapeInputs.end())
+        continue;
+    }
+
+    cout << "  initializer { \n";
+    cout << it->DebugString();
+    cout << " }\n";
+  }
+}
+
+static void dumpGraphProto(const xGraphProto &pGraph)
+{
+  int i;
+  set<string> reshapeInputs;
+
+  cout << "graph {\n";
+  cout << "  name: \"" << pGraph.name() << "\"\n";
+  cout << "  doc_string: \"" << pGraph.doc_string() << "\"\n";
+
+  dumpNodeProto(pGraph.node(), reshapeInputs);
+
+  for (i = 0; i < pGraph.input_size(); i++)
+    cout << "  input { " << pGraph.input(i).ShortDebugString() << " }\n";
+
+  for (i = 0; i < pGraph.output_size(); i++)
+    cout << "  output { " << pGraph.output(i).ShortDebugString() << " }\n";
+
+  for (i = 0; i < pGraph.value_info_size(); i++)
+    cout << "  value_info { " << pGraph.value_info(i).ShortDebugString()
+         << " }\n";
+
+  dumpTensorProto(pGraph.initializer(), reshapeInputs);
+
+  cout << "}\n";
+}
+
+static void dumpModelProto(const xProto &pModel)
+{
+  int i;
+
+  cout << "ir_version: " << pModel.ir_version() << "\n";
+  cout << "producer_name: \"" << pModel.producer_name() << "\"\n";
+  cout << "producer_version: \"" << pModel.producer_version() << "\"\n";
+  cout << "domain: \"" << pModel.domain() << "\"\n";
+  cout << "model_version: " << pModel.model_version() << "\n";
+  cout << "doc_string: \"" << pModel.doc_string() << "\"\n";
+
+  if (pModel.has_graph())
+    dumpGraphProto(pModel.graph());
+
+  for (i = 0; i < pModel.opset_import_size(); ++i) {
+    cout << "opset_import { " << pModel.opset_import(i).ShortDebugString()
+         << " }\n";
+  }
+  for (i = 0; i < pModel.metadata_props_size(); ++i) {
+    cout << "metadata_props { " << pModel.metadata_props(i).ShortDebugString()
+         << " }\n";
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Main function
+//===----------------------------------------------------------------------===//
+int main(int pArgc, char *pArgv[])
+{
+  GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+  cl::ParseCommandLine(pArgc, pArgv);
+  if (OptHelp) {
+    g_About.print(outs());
+    return EXIT_SUCCESS;
+  }
+
+  xProto model;
+  string fileName(InputFilename);
+
+  {
+    std::ifstream input(fileName, std::ifstream::binary);
+    ::google::protobuf::io::IstreamInputStream inputStream(&input);
+    ::google::protobuf::io::CodedInputStream codeInputStream(&inputStream);
+    codeInputStream.SetTotalBytesLimit(1024LL << 20, 512LL << 20);
+    if (!model.ParseFromCodedStream(&codeInputStream)) {
+      std::cerr << "Failed to parse xProto.\n";
+      return EXIT_FAILURE;
+    }
+  }
+
+  dumpModelProto(model);
+
+  google::protobuf::ShutdownProtobufLibrary();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`onnx-as` and `onnx-dis` are related to onnx and not that tight to onnc.

For cleaner project architecture, moving them from onnc source to umbrella is better.

This pull request is referred with https://github.com/ONNC/onnc/pull/44 .