### PR TITLE
Check cmake building status in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,17 +30,48 @@ jobs:
             - "build-llvm"
             - "build-onnx"
             - "build-SkyPat"
+  "ubuntu-latest-build-cmake":
+    docker:
+      - image: ubuntu:latest
+    steps:
+      - run:
+          name: "Install CircleCI prerequisite"
+          command:
+            apt-get update && apt-get install -y git ssh tar gzip ca-certificates
+      - checkout
+      - run:
+          name: "Install prerequisite"
+          command: 
+            apt-get install -y gcc g++ cmake curl automake libtool protobuf-compiler libprotoc-dev pkg-config python2.7 python2.7-dev python-pip libgoogle-glog-dev libboost-filesystem-dev flex bison
+      - restore_cache:
+          keys:
+            - ubuntu-latest-external
+      - run:
+          name: "Update git submodule"
+          command: 
+            git submodule init && git submodule update
+      - run:
+          name: "Build"
+          command: 
+            mkdir install && ./build.cmake.sh normal ./install
+      - save_cache:
+          key: ubuntu-latest-external
+          paths:
+            - "build-llvm"
+            - "build-onnx"
+            - "build-SkyPat"
 workflows:
   version: 2
   nightly:
     triggers:
       - schedule:
-          cron: "22 12 * * *"
+          cron: "52 4 * * *"
           filters:
             branches:
               only:
                 - master
+                - ci
     jobs:
       - "ubuntu-latest-build"
-      
+      - "ubuntu-latest-build-cmake"
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,20 +76,12 @@ workflows:
 
   ci-config-test:
     jobs:
-      - "build-automake":
-          type: approval
-      - "build-cmake":
-          type: approval
       - "ubuntu-latest-build":
-          requires:
-            - "build-automake"
           filters:
             branches:
               only:
                 - ci
       - "ubuntu-latest-build-cmake":
-          requires:
-            - "build-cmake"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,13 +65,32 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "52 4 * * *"
+          cron: "0 16 * * *"
           filters:
             branches:
               only:
                 - master
-                - ci
     jobs:
       - "ubuntu-latest-build"
       - "ubuntu-latest-build-cmake"
-      
+
+  ci-config-test:
+    jobs:
+      - "build-automake":
+          type: approval
+      - "build-cmake":
+          type: approval
+      - "ubuntu-latest-build":
+          requires:
+            - "build-automake"
+          filters:
+            branches:
+              only:
+                - ci
+      - "ubuntu-latest-build-cmake":
+          requires:
+            - "build-cmake"
+          filters:
+            branches:
+              only:
+                - ci

--- a/build.cmake.sh
+++ b/build.cmake.sh
@@ -134,45 +134,37 @@ function build_onnc
     normal)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Release \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
-                          -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DONNX_ROOT="${ONNC_EXTDIR}" \
                           -DONNX_NAMESPACE=onnx \
-                          -DSKYPAT_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DSKYPAT_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DSKYPAT_ROOT="${ONNC_EXTDIR}" \
                           ${ONNC_SRCDIR}
       ;;
     dbg)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Debug \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
-                          -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DONNX_ROOT="${ONNC_EXTDIR}" \
                           -DONNX_NAMESPACE=onnx \
-                          -DSKYPAT_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DSKYPAT_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DSKYPAT_ROOT="${ONNC_EXTDIR}" \
                           ${ONNC_SRCDIR}
       ;;
     rgn)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Regression \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
-                          -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DONNX_ROOT="${ONNC_EXTDIR}" \
                           -DONNX_NAMESPACE=onnx \
-                          -DSKYPAT_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DSKYPAT_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DSKYPAT_ROOT="${ONNC_EXTDIR}" \
                           ${ONNC_SRCDIR}
       ;;
     opt)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Optimized \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
                           -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
-                          -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DONNX_ROOT="${ONNC_EXTDIR}" \
                           -DONNX_NAMESPACE=onnx \
-                          -DSKYPAT_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
-                          -DSKYPAT_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
+                          -DSKYPAT_ROOT="${ONNC_EXTDIR}" \
                           ${ONNC_SRCDIR}
       ;;
     *)

--- a/build.cmake.sh
+++ b/build.cmake.sh
@@ -134,7 +134,7 @@ function build_onnc
     normal)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Release \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
                           -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
                           -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
                           -DONNX_NAMESPACE=onnx \
@@ -145,7 +145,7 @@ function build_onnc
     dbg)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Debug \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
                           -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
                           -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
                           -DONNX_NAMESPACE=onnx \
@@ -156,7 +156,7 @@ function build_onnc
     rgn)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Regression \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
                           -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
                           -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
                           -DONNX_NAMESPACE=onnx \
@@ -167,7 +167,7 @@ function build_onnc
     opt)
       fail_panic "CMake onnc failed." cmake -DCMAKE_BUILD_TYPE=Optimized \
                           -DCMAKE_INSTALL_PREFIX="${ONNC_PREFIX}" \
-                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}" \
+                          -DLLVM_ROOT_DIR="${ONNC_EXTDIR}/lib/cmake/llvm" \
                           -DONNX_INCLUDE_DIR="${ONNC_EXTDIR}/include" \
                           -DONNX_LIBRARY_DIR="${ONNC_EXTDIR}/lib" \
                           -DONNX_NAMESPACE=onnx \


### PR DESCRIPTION
CI system only checks automake building status currently.

This patch will also check cmake building system, and fix onnx & skypat root path configurations in `build.cmake.sh`.