### PR TITLE
Regmod

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(ONNC_UMBRELLA_ROOT ${CMAKE_CURRENT_LIST_DIR})
 
 # Set build type
-set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type [Release(default)/Debug/Regression]")
+set(CMAKE_BUILD_TYPE "normal")
+#set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Build type [Release(default)/Debug/Regression]")
+Message("build type is ${CMAKE_BUILD_TYPE}")
  # for build.cmake.sh
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     option(ENABLE_UNITTEST "enable unittest" ON)
@@ -19,11 +21,18 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 
 # Build
 # TODO: Integrate src CMake later
+#add_subdirectory(src)
 
 add_custom_target(onnc ALL
     COMMAND MAX_MAKE_JOBS=$ENV{MAX_MAKE_JOBS} ./build.cmake.sh ${build_mode_for_command} ${CMAKE_INSTALL_PREFIX}
     WORKING_DIRECTORY ${ONNC_UMBRELLA_ROOT}
 )
+
+# create folder for each model
+execute_process(
+	COMMAND sh make_models_test.sh 
+	WORKING_DIRECTORY ${ONNC_UMBRELLA_ROOT}
+	)
 
 # Test
 add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_custom_target(onnc ALL
 
 # create folder for each model
 execute_process(
-	COMMAND sh make_models_test.sh 
+	COMMAND sh make_models_test.sh ${PROJECT_BINARY_DIR}
 	WORKING_DIRECTORY ${ONNC_UMBRELLA_ROOT}
 	)
 

--- a/make_models_test.sh
+++ b/make_models_test.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-#                       The ONNC Project
+working_dir=$1 # receiving the build direcotory from CMakeLists.txt
+
+# copy python test script to the build directory
+cp test_onni_dump.py ${working_dir}
 
 ONNX_MODEL_LIST=`ls -C -w 0 /models/`
 
 for model in ${ONNX_MODEL_LIST}; do
     echo "create ${model} directory"
-    mkdir -p test/regression/onni-"${model}"
-    echo "#!/bin/bash" > test/regression/onni-"${model}"/main.sh
-	echo "onni /models/${model}/model.onnx /models/${model}/test_data_set_0/input_0.pb -o test/regression/onni-"${model}"/output-onni.pb" \
-		>> test/regression/onni-"${model}"/main.sh
+    mkdir -p test/regression/test_"${model}"
+    echo "#!/bin/bash" > test/regression/test_"${model}"/main.sh
+	echo "python ${working_dir}/test_onni_dump.py ${model}" >> test/regression/test_"${model}"/main.sh
 done

--- a/make_models_test.sh
+++ b/make_models_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#                       The ONNC Project
+
+ONNX_MODEL_LIST=`ls -C -w 0 /models/`
+
+for model in ${ONNX_MODEL_LIST}; do
+    echo "create ${model} directory"
+    mkdir -p test/regression/onni-"${model}"
+    echo "#!/bin/bash" > test/regression/onni-"${model}"/main.sh
+	echo "onni /models/${model}/model.onnx /models/${model}/test_data_set_0/input_0.pb -o test/regression/onni-"${model}"/output-onni.pb" \
+		>> test/regression/onni-"${model}"/main.sh
+done

--- a/scripts/library.sh
+++ b/scripts/library.sh
@@ -159,6 +159,7 @@ function build_autotools_project
 
 function build_cmake_project
 {
+  set -x
   local SRCDIR=$1
   local NAME=$(basename "${SRCDIR}")
   local BUILDDIR=$(getabs "build-${NAME}")
@@ -183,6 +184,7 @@ function build_cmake_project
 
   show "finishing ..."
   popd > /dev/null
+  set +x
 }
 
 function build_handcraft_project

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 file(GLOB regression_tests RELATIVE ${CMAKE_CURRENT_LIST_DIR}/regression regression/*)
 
 foreach(regression_test IN LISTS regression_tests)
+	message("adding test ${regression_test}")
     add_test(
         NAME ${regression_test}
         COMMAND bash "${CMAKE_CURRENT_LIST_DIR}/regression/${regression_test}/main.sh"

--- a/test_onni_dump.py
+++ b/test_onni_dump.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from onnx import numpy_helper
+from io import StringIO
+from subprocess import check_output, CalledProcessError
+
+import shlex
+import numpy
+import onnx
+import sys
+import os
+import io
+import re
+
+
+model_path = '/models/'
+
+class TestOnniDump:
+
+
+	def discovery_testcase(self, model_name):
+		"""
+		find the test cases under the model_path/model_name
+
+		Parameters
+		==========
+		model_name: the name of model under which test cases will be discovered
+		"""
+		test_cases = []
+		for fn in os.listdir(os.path.join(model_path, model_name)):
+			if fn.startswith('test') and os.path.isdir(os.path.join(model_path, model_name, fn)):
+				test_cases.append(fn)
+		return test_cases
+
+	def read_output_pb(self, filename):
+		"""
+		parse the protobuf file into onnx.tensor
+
+		Parameters
+		==========
+		filename: the filename pointing to a protobuf pb file
+		"""
+		tensor = onnx.TensorProto()
+		with io.open(filename, 'rb') as f:
+			tensor.ParseFromString(f.read())
+		true_array = numpy_helper.to_array(tensor)
+		return true_array
+
+	def parse_onni_stdout(self, logfile='output_0.log'):
+		"""
+		This function parse the stdout (if outputing array)
+		
+		Parameters
+		==========
+		logfile: the filename pointing to the stdout dump
+		"""
+		buf = None
+		with io.open(logfile, encoding='utf-8') as fp:
+			for line in fp:
+				if not line.startswith('[v') and line:
+					buf = StringIO(re.sub(r'[^\d.+-]', ' ', line, flags=re.U))
+		if buf:
+			output_array = numpy.fromstring(buf.getvalue(), sep=" ")
+			return output_array
+
+	def test_stdout(self, model_name, testcase_name):
+		"""
+		test the single testcase given the model name through the stdout dump
+
+		Parameters
+		==========
+		model_name: the name of testing model
+		testcase_name: testcase name of testing model
+		"""
+		truepb_fn = os.path.join(model_path, model_name, testcase_name, 'output_0.pb')
+		true_array = case.read_output_pb(truepb_fn)
+		outpb_fn = os.path.join('output-%s-%s.log' % (model_name, testcase_name))
+		output_array = case.parse_onni_stdout(outpb_fn)
+		output_array = output_array.reshape(true_array.shape).astype(true_array.dtype)
+		numpy.testing.assert_allclose(true_array, output_array)	
+
+	def test_pb(self, model_name, testcase_name):
+		"""
+		test the single testcase given the model name through the output protobuf written 
+		on disk
+
+		Parameters
+		==========
+		model_name: the name of testing model
+		testcase_name: testcase name of testing model
+		"""
+		truepb_fn = os.path.join(model_path, model_name, testcase_name, 'output_0.pb')
+		true_array = case.read_output_pb(truepb_fn)
+		outpb_fn = os.path.join('output-%s-%s.pb' % (model_name, testcase_name))
+		output_array = case.read_output_pb(outpb_fn)
+		numpy.testing.assert_allclose(true_array, output_array)	
+
+
+if __name__ == '__main__':
+	model_name = sys.argv[1]
+	case = TestOnniDump()
+	test_cases = case.discovery_testcase(model_name)
+	
+	numcase_of_failing = 0	 
+	for case_name in test_cases:
+		cmd = "onni /models/{model}/model.onnx /models/{model}/{testcase}/input_0.pb" \
+	          " -o output-{model}-{testcase}.pb".format(
+	          model=model_name, testcase=case_name) 
+		try:
+			output = check_output(shlex.split(cmd), universal_newlines=True)	
+		except CalledProcessError as e:
+			if e.returncode >= 0:
+				print(e.stderr)
+		else:
+			with open('output-{model}-{testcase}.log'.format(
+					model=model_name, testcase=case_name), 'wt') as fp:
+					fp.write(output)
+
+		try:
+			case.test_stdout(model_name, case_name)
+		except AssertionError:
+			numcase_of_failing += 1
+
+	assert(numcase_of_failing == 0)


### PR DESCRIPTION
This request is the work to complete regression model test. There are two files: one is shell script , make _models_test.h and test_onni_dump.py

make _models_test.h: the main functionality is to create subfolder under the main test/regression folder. Each subfolder will hold a model name (/models) and several test cases depending on the original model settings. This way is compatible to the test/CMakeList.txt which relies on walking directory to discover test case. In order to make make _models_test work, some modifications are made to CMakeLists.txt file in the project root. 
test_onni_dump.py: this python script will be invoked through the main.sh. Given model name. each test case will be firstly discovered by python script. And python will parse stdout or disk protobuf file dump and report assertion failure. 
